### PR TITLE
Memory leaks

### DIFF
--- a/libparistraceroute/address.c
+++ b/libparistraceroute/address.c
@@ -146,6 +146,9 @@ bool address_guess_family(const char * str_ip, int * pfamily) {
 
     // We retrieve family from the first result
     *pfamily = result->ai_family;
+
+    freeaddrinfo(result);
+
     return true;
 
 ERR_NO_RESULT:

--- a/libparistraceroute/event.c
+++ b/libparistraceroute/event.c
@@ -26,9 +26,6 @@ void event_free(event_t * event)
         if (event->data && event->data_free) {
             event->data_free(event->data);
         }
-        ///////////// TODO
-        //free(event);
-        event->data = NULL; // DEBUG
-        ///////////// TODO
+        free(event);
     }
 }

--- a/libparistraceroute/network.c
+++ b/libparistraceroute/network.c
@@ -691,7 +691,8 @@ bool network_process_recvq(network_t * network)
     probe_reply_set_reply(probe_reply, reply);
 
     // Notify the instance which has build the probe that we've got the corresponding reply
-    pt_throw(NULL, probe->caller, event_create(PROBE_REPLY, probe_reply, NULL, NULL)); // TODO probe_reply_free frees only the reply
+    pt_throw(NULL, probe->caller, event_create(PROBE_REPLY, probe_reply, NULL, (ELEMENT_FREE) probe_reply_free));
+    // TODO probe_reply_free frees only the reply but probe_reply_deep_free cannot be used as other things may have references to its contents.
     return true;
 
 ERR_PROBE_REPLY_CREATE:

--- a/libparistraceroute/probe.c
+++ b/libparistraceroute/probe.c
@@ -488,8 +488,7 @@ probe_t * probe_wrap_packet(packet_t * packet)
     }
 
     // Clear the probe
-    // The actual value of probe->packet is not freed since it
-    // can pointed by another probe_t instance.
+    packet_free(probe->packet);
     probe->packet = packet;
     probe_layers_clear(probe);
 


### PR DESCRIPTION
Fix various memory leaks. This brings the number of reported problems in valgrind down from 172 to 141 when run against fakeroute with `./libtool --mode=execute valgrind --log-file=test-probe_reply_free.log --leak-check=full ./paris-traceroute/paris-traceroute --tcp --algorithm=mda 1.1.1.1`
