### PR TITLE
Fix bug in probe_group

### DIFF
--- a/libparistraceroute/probe_group.c
+++ b/libparistraceroute/probe_group.c
@@ -249,7 +249,7 @@ void probe_group_iter_next_scheduled_probes(
         } else if (is_probe(child) && get_node_delay(child) == delay) {
             if (callback) callback(param_callback, child, i);
             num_children = tree_node_get_num_children(node);
-            i = 0;
+            i = -1;
         } else probe_group_iter_next_scheduled_probes(child, callback, param_callback);
     }
 }


### PR DESCRIPTION
`++i` in the `for`-loop will increment `i` by `1`. Since we want to restart the loop, we have to set `i` to `-1`, such that after incrementing the next loop will really start at `0`.
Otherwise, this bug can cause probes to not be scheduled, which can lead to infinite loops.