### PR TITLE
Do not stall when using probe_count=1

### DIFF
--- a/libparistraceroute/probe_group.c
+++ b/libparistraceroute/probe_group.c
@@ -85,7 +85,7 @@ void  probe_group_update_delay(probe_group_t * probe_group, tree_node_t * node) 
         }
     } else {
         if (probe_group_get_next_delay(probe_group) < DBL_MAX) {
-            if (probe_group_get_next_delay(probe_group) - probe_group_get_last_delay(probe_group) < 0) {
+            if (probe_group_get_next_delay(probe_group) - probe_group_get_last_delay(probe_group) <= 0) {
                 probe_group_set_last_delay(probe_group, 0);
             }
 


### PR DESCRIPTION
When `probe_count = 1`, the `probe_group`'s `last_delay` will be set to the `delay` of this probe.
Now, when adding a "new" probe to discover the next hop to the `probe_group`, `next_delay` and `last_delay` will be identical, i.e. `next_delay - last_delay == 0`.
Thus `update_time` would actually disarm the timer, which causes the new probe to never be scheduled.

The proposed fix resets `last_delay` to zero also in the case of identical delays, which correctly schedules the new probe.