### PR TITLE
Prevent infinite loop caused by erroneous events

### DIFF
--- a/libparistraceroute/algorithm.c
+++ b/libparistraceroute/algorithm.c
@@ -301,9 +301,6 @@ void pt_stop_instance(
         struct pt_loop_s     * loop,
         algorithm_instance_t * instance
 ) {
-    // Notify the caller that this instance will be freed
-    pt_throw(NULL, instance, event_create(ALGORITHM_TERM, NULL, NULL, NULL));
-
     // Unregister this instance from the loop
     pt_algorithm_instance_del(loop, instance);
 


### PR DESCRIPTION
`pt_stop_instance` should *not* emit a `ALGORITHM_TERM` event, since the algorithm instance that could handle it will be freed immediately afterwards.
This would trigger an infinite loop in `pt_loop`, since the algorithms' `eventfd` would always report one pending event, but none of the remaining algorithm instances would handle it (i.e. read from `eventfd`).