### PR TITLE
fixed protocol field update in packet headers

### DIFF
--- a/libparistraceroute/probe.c
+++ b/libparistraceroute/probe.c
@@ -138,7 +138,7 @@ static bool probe_update_protocol(probe_t * probe)
         layer = probe_get_layer(probe, i);
         if (layer->protocol && prev_layer) {
             // Update 'protocol' field (if any)
-            layer_set_field_and_free(layer, I8("protocol", prev_layer->protocol->protocol));
+            layer_set_field_and_free(prev_layer, I8("protocol", layer->protocol->protocol));
         }
     }
     return true;


### PR DESCRIPTION
Layer considered in the update were swapped. I am surprised this problem has not been raised before, but it shows up easily when stacking more layers on top of each other.