### PR TITLE
Export data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AC_DEFINE([BSDSOCKET], [1], [BSD socket interface])
 #jo#trpt_others="yes"
 #jo#trpt_buggy="no"
 
-CFLAGS="$CFLAGS -Wall -Werror"
+CFLAGS="$CFLAGS -Wall"
 
 #############
 ## Options ##
@@ -158,13 +158,17 @@ AC_HEADER_TIME(, AC_MSG_ERROR("header time missing"))
 
 # Checks for library functions.
 AC_FUNC_ERROR_AT_LINE
-AC_FUNC_MALLOC
+#AC_FUNC_MALLOC
 AC_CHECK_FUNC([inet_ntoa])
 AC_CHECK_FUNC([memset])
 AC_CHECK_FUNC([socket])
 AC_CHECK_FUNC([strdup])
 AC_CHECK_FUNC([strerror])
 
+AC_CHECK_FUNC([twalk])
+AC_CHECK_FUNC([timerfd_create])
+AC_CHECK_FUNC([timerfd_settime])
+AC_CHECK_FUNC([epoll_create1])
 #################################################################################
 #
 # Compile time options

--- a/libparistraceroute/address.c
+++ b/libparistraceroute/address.c
@@ -1,5 +1,6 @@
 #include "use.h"
 #include "config.h"
+//#include "common.h"
 
 #include <stdio.h>      // perror
 #include <stdlib.h>     // malloc
@@ -15,6 +16,8 @@
 #endif
 
 #include "address.h"
+
+extern bool _doPrint;
 
 #ifdef USE_CACHE
 #    include "containers/map.h"
@@ -43,10 +46,11 @@ static void __cache_ip_hostname_free() {
 
 static void ip_dump(int family, const void * ip, char * buffer, size_t buffer_len) {
     if (inet_ntop(family, ip, buffer, buffer_len)) {
-        printf("%s", buffer);
-    } else {
-        printf("???");
-    }
+        if (_doPrint)
+						printf("%s", buffer);
+    } else
+		if (_doPrint)
+				printf("???");
 }
 
 int ip_from_string(int family, const char * hostname, ip_t * ip) {
@@ -117,9 +121,13 @@ void ipv6_dump(const ipv6_t * ipv6) {
 }
 #endif
 
-void address_dump(const address_t * address) {
-    char buffer[INET6_ADDRSTRLEN];
-    ip_dump(address->family, &address->ip, buffer, INET6_ADDRSTRLEN);
+void address_dump(const address_t * address, char * oIPStr, uint8_t iIPStrLen) {
+		if (oIPStr && iIPStrLen)
+				ip_dump(address->family, &address->ip, oIPStr, iIPStrLen);
+		else {
+				char buffer[INET6_ADDRSTRLEN];
+				ip_dump(address->family, &address->ip, buffer, INET6_ADDRSTRLEN);
+		}
 }
 
 bool address_guess_family(const char * str_ip, int * pfamily) {

--- a/libparistraceroute/address.h
+++ b/libparistraceroute/address.h
@@ -181,6 +181,14 @@ int address_to_string(const address_t * addr, char ** pbuffer);
 
 bool address_resolv(const address_t * address, char ** phostname, int mask_cache);
 
+/**
+ * \brief Gets the IP of the local peer.
+ * \param oAddr the address returned, must not be null
+ * \param oIP the IP returned if provided, must be freed by the caller
+ * \param oHostName the host name returned if provided, must be freed by the caller
+ */
+bool getLocalAddress(address_t * oAddr, char ** oIP, char ** oHostName);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libparistraceroute/address.h
+++ b/libparistraceroute/address.h
@@ -6,6 +6,10 @@
 
 #include "use.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //---------------------------------------------------------------------------
 // ip*_t
 //---------------------------------------------------------------------------
@@ -174,5 +178,9 @@ int address_to_string(const address_t * addr, char ** pbuffer);
 #define CACHE_ENABLED  (CACHE_READ | CACHE_WRITE)
 
 bool address_resolv(const address_t * address, char ** phostname, int mask_cache);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ADDRESS_H

--- a/libparistraceroute/address.h
+++ b/libparistraceroute/address.h
@@ -118,9 +118,11 @@ size_t address_get_size(const address_t * address);
 /**
  * \brief Print an address
  * \param address The address to print
+ * \param oIPStr if not ULL, it's a preallocated string to store a IP in string format
+ * \param iIPStrLen the length in bytes of \coIPStr
  */
 
-void address_dump(const address_t * address);
+void address_dump(const address_t * address, char * oIPStr, uint8_t iIPStrLen);
 
 /**
  * \brief Guess address family of an IP by using the

--- a/libparistraceroute/algorithm.h
+++ b/libparistraceroute/algorithm.h
@@ -14,6 +14,10 @@
 #include "pt_loop.h"    // pt_loop_t
 #include "optparse.h"   // opt_spec
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \enum status_t
  * \brief Algorithm status constants
@@ -195,5 +199,9 @@ void pt_del_instance(
     struct pt_loop_s * loop,
     algorithm_instance_t * instance
 );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHM_H

--- a/libparistraceroute/algorithms/mda.c
+++ b/libparistraceroute/algorithms/mda.c
@@ -140,7 +140,7 @@ static bool mda_event_new_link(pt_loop_t * loop, mda_interface_t * src, mda_inte
     if (!(link = malloc(2 * sizeof(mda_interface_t)))) goto ERR_LINK;
     link[0] = src;
     link[1] = dst;
-    if (!(mda_event = event_create(MDA_NEW_LINK, link, NULL, free))) goto ERR_MDA_EVENT;
+    if (!(mda_event = event_create((event_type_t)MDA_NEW_LINK, link, NULL, free))) goto ERR_MDA_EVENT;
     return pt_raise_event(loop, mda_event);
 
 ERR_MDA_EVENT:

--- a/libparistraceroute/algorithms/mda.c
+++ b/libparistraceroute/algorithms/mda.c
@@ -263,7 +263,7 @@ static lattice_return_t mda_enumerate(lattice_elt_t * elt, mda_data_t * mda_data
         mda_ttl_flow = mda_interface_get_available_flow_id(interface, num_siblings, mda_data);
         if (!mda_ttl_flow) {
             fprintf(stderr, "Not enough flows found reaching: ");
-            address_dump(interface->address);
+            address_dump(interface->address, NULL, 0);  // \todo: if no printf is required(cf setPrintMode()), pass a buffer here
             break;
         }
         

--- a/libparistraceroute/algorithms/mda.h
+++ b/libparistraceroute/algorithms/mda.h
@@ -8,6 +8,10 @@
 #include "../optparse.h"
 #include "../vector.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //mda command line help messages
 #define HELP_B "Multipath tracing  bound: an upper bound on the probability that multipath tracing will fail to find all of the paths (default 0.05) max_branch: the maximum number of branching points that can be encountered for the bound still to hold (default 5)"
 
@@ -62,5 +66,9 @@ void options_mda_init(mda_options_t * mda_options);
  */
 
 int mda_handler(pt_loop_t * loop, event_t * event, void ** pdata, probe_t * skel, void * options);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_MDA_H

--- a/libparistraceroute/algorithms/mda/data.h
+++ b/libparistraceroute/algorithms/mda/data.h
@@ -7,6 +7,10 @@
 #include "../../pt_loop.h"  // pt_loop_t
 #include "../../probe.h"    // probe_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     lattice_t    * lattice;      /**< Root of the lattice storing the interfaces */
     uintmax_t      last_flow_id;
@@ -29,5 +33,9 @@ mda_data_t * mda_data_create();
  */
 
 void mda_data_free(mda_data_t * data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_MDA_DATA_H

--- a/libparistraceroute/algorithms/mda/flow.h
+++ b/libparistraceroute/algorithms/mda/flow.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
     MDA_FLOW_AVAILABLE,
     MDA_FLOW_UNAVAILABLE,
@@ -42,5 +46,9 @@ void mda_flow_free(mda_flow_t * mda_flow);
  * \return The corresponding caractère, 'E' in case of failure.
  */
 char mda_flow_state_to_char(const mda_flow_t * mda_flow);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_MDA_FLOW_H

--- a/libparistraceroute/algorithms/mda/interface.c
+++ b/libparistraceroute/algorithms/mda/interface.c
@@ -161,7 +161,7 @@ static void flow_dump(const mda_interface_t * interface)
 static void mda_hop_dump(const mda_interface_t * hop, char * hostname)
 {
     if (hop->address) {
-        address_dump(hop->address);
+        address_dump(hop->address, NULL, 0);  // \todo: pass a string if no printf is required(cf setPrintMode())
     } else printf("None");
     if (hostname) {
         printf(" (%s)", hostname);

--- a/libparistraceroute/algorithms/mda/interface.h
+++ b/libparistraceroute/algorithms/mda/interface.h
@@ -10,6 +10,10 @@
 #include "../../address.h"  // address_t
 #include "../../dynarray.h" // dynarray_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
     MDA_LB_TYPE_UNKNOWN,             /**< IP hop state not yet classified  */
     MDA_LB_TYPE_IN_PROGRESS,         /**< IP hop not yet classified        */
@@ -121,5 +125,9 @@ void mda_link_dump(const mda_interface_t ** link, bool do_resolv);
  */
 
 void mda_lattice_elt_dump(const lattice_elt_t * elt); //, bool do_resolv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_MDA_INTERFACE_H

--- a/libparistraceroute/algorithms/mda/ttl_flow.h
+++ b/libparistraceroute/algorithms/mda/ttl_flow.h
@@ -6,6 +6,10 @@
 #define MAX_TTLS 5 // Max ttls we assume can be associated with this interface
                    // TODO Avoid hardcoding
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     uint8_t      ttl;
     mda_flow_t * mda_flow;
@@ -26,5 +30,9 @@ mda_ttl_flow_t * mda_ttl_flow_create(uint8_t ttl, mda_flow_t * mda_flow);
  */
 
 void mda_ttl_flow_free(mda_ttl_flow_t * mda_ttl_flow);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_MDA_TTL_FLOW_H

--- a/libparistraceroute/algorithms/ping.c
+++ b/libparistraceroute/algorithms/ping.c
@@ -532,12 +532,12 @@ static inline void discovered_ip_dump(const probe_t * reply, bool do_resolv) {
                 printf("%s", discovered_hostname);
                 free(discovered_hostname);
             } else {
-                address_dump(&discovered_addr);
+                address_dump(&discovered_addr, NULL, 0); // \todo: pass a string if no printf is required (cf setPrintMode())
             }
             printf(" (");
         }
 
-        address_dump(&discovered_addr);
+        address_dump(&discovered_addr, NULL, 0); // \todo: pass a string if no printf is required (cf setPrintMode())
 
         if (do_resolv) {
             printf(")");

--- a/libparistraceroute/algorithms/traceroute.c
+++ b/libparistraceroute/algorithms/traceroute.c
@@ -194,13 +194,13 @@ void traceroute_handler(
     const probe_t * probe;
     const probe_t * reply;
     static size_t   num_probes_printed = 0;
-
+    
     if (traceroute_data->hostName) {
         free(traceroute_data->hostName);
         traceroute_data->hostName = NULL;
     }
     traceroute_data->newHop = false;
-    traceroute_data->rtt = 0;
+    traceroute_data->rtt = -1;
     traceroute_data->replyTTL = 0;
     
     switch (traceroute_event->type) {
@@ -213,12 +213,12 @@ void traceroute_handler(
             
             // Print TTL and discovered IP if this is the first probe related to this TTL
             if (traceroute_data->newHop) {
-                if (probe_extract(probe, "ttl", &(traceroute_data->attemptedTTL))) {
+                if (probe_extract(probe, "ttl", &(traceroute_data->attemptTTL))) {
                     if (_doPrint)
-                        printf("%2d(%2d) ", traceroute_data->attemptedTTL, traceroute_data->ttl);
+                        printf("%2d(%2d) ", traceroute_data->attemptTTL, traceroute_data->ttl);
                 }
                 else
-                    traceroute_data->attemptedTTL = 0;
+                    traceroute_data->attemptTTL = 0;
 
                 discovered_ip_dump(reply, traceroute_options->do_resolv,
                                   (traceroute_options->resolv_asn ? &traceroute_data->asn : NULL),
@@ -231,9 +231,9 @@ void traceroute_handler(
 								printf("  %-5.3lfms  ", 1000 * traceroute_data->rtt);
 						
 						// Handles reply's ttl
-            if (traceroute_options->print_ttl) {
-								if (probe_extract(reply, "ttl", &traceroute_data->replyTTL) && _doPrint)
-										printf("[%2d] ", traceroute_data->replyTTL);
+            if (probe_extract(reply, "ttl", &traceroute_data->replyTTL) && _doPrint &&
+                      traceroute_options->print_ttl) {
+                printf("[%2d] ", traceroute_data->replyTTL);
 						}
             fflush(stdout);
             num_probes_printed++;
@@ -245,12 +245,12 @@ void traceroute_handler(
             traceroute_data->newHop = (num_probes_printed % traceroute_options->num_probes == 0);
 
             if (traceroute_data->newHop) {
-								if (probe_extract(probe, "ttl", &traceroute_data->attemptedTTL)) {
+								if (probe_extract(probe, "ttl", &traceroute_data->attemptTTL)) {
 									if (_doPrint)
-										printf("%2d(%2d) ", traceroute_data->attemptedTTL, traceroute_data->ttl);
+										printf("%2d(%2d) ", traceroute_data->attemptTTL, traceroute_data->ttl);
 								}
 								else
-									traceroute_data->attemptedTTL = 0;
+									traceroute_data->attemptTTL = 0;
             }
 						if (_doPrint)
 								printf(" *");

--- a/libparistraceroute/algorithms/traceroute.c
+++ b/libparistraceroute/algorithms/traceroute.c
@@ -215,7 +215,7 @@ void traceroute_handler(
             if (traceroute_data->newHop) {
                 if (probe_extract(probe, "ttl", &(traceroute_data->attemptedTTL))) {
                     if (_doPrint)
-                        printf("%2d(%2d) ", traceroute_data->attemptedTTL, traceroute_data->ttl);
+                        printf("%2d ", traceroute_data->attemptedTTL);
                 }
                 else
                     traceroute_data->attemptedTTL = 0;
@@ -247,7 +247,7 @@ void traceroute_handler(
             if (traceroute_data->newHop) {
 								if (probe_extract(probe, "ttl", &traceroute_data->attemptedTTL)) {
 									if (_doPrint)
-										printf("%2d(%2d) ", traceroute_data->attemptedTTL, traceroute_data->ttl);
+										printf("%2d ", traceroute_data->attemptedTTL);
 								}
 								else
 									traceroute_data->attemptedTTL = 0;

--- a/libparistraceroute/algorithms/traceroute.h
+++ b/libparistraceroute/algorithms/traceroute.h
@@ -120,6 +120,11 @@ typedef struct {
 typedef struct {
     bool          destination_reached; /**< True iif the destination has been reached at least once for the current TTL */
     uint8_t       ttl;                 /**< TTL currently explored                   */
+    uint8_t       replyTTL;            /**< Current TTL sent back with the reply		 */
+		double				rtt;								 /**< Current rtt                   					 */
+		uint32_t			asn;								 /**< Current ASN if resolution is required		 */
+		char					ip[INET6_ADDRSTRLEN];/**< Current replying IP											 */
+		char				* hostName;						 /**< Current host name. Should be freed if filled by discovered_ip_dump() */
     size_t        num_replies;         /**< Total of probe sent for this instance    */
     size_t        num_undiscovered;    /**< Number of consecutive undiscovered hops  */
     size_t        num_stars;           /**< Number of probe lost for the current hop */
@@ -142,9 +147,10 @@ void traceroute_handler(
     pt_loop_t                  * loop,
     traceroute_event_t         * traceroute_event,
     const traceroute_options_t * traceroute_options,
-    const traceroute_data_t    * traceroute_data
+    traceroute_data_t    			 * traceroute_data
 );
 
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/libparistraceroute/algorithms/traceroute.h
+++ b/libparistraceroute/algorithms/traceroute.h
@@ -31,6 +31,10 @@
 #define TRACEROUTE_HELP_PRINT_TTL "Print the TTL of the reply packet."
 #define TRACEROUTE_HELP_M "Set the maximum number of consecutive unresponsive hops which causes the program to abort (default 3)."
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Get the different values of traceroute options
 uint8_t options_traceroute_get_min_ttl();
 uint8_t options_traceroute_get_max_ttl();
@@ -140,5 +144,9 @@ void traceroute_handler(
     const traceroute_options_t * traceroute_options,
     const traceroute_data_t    * traceroute_data
 );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_ALGORITHMS_TRACEROUTE_H

--- a/libparistraceroute/algorithms/traceroute.h
+++ b/libparistraceroute/algorithms/traceroute.h
@@ -120,9 +120,11 @@ typedef struct {
 typedef struct {
     bool          destination_reached; /**< True iif the destination has been reached at least once for the current TTL */
     uint8_t       ttl;                 /**< TTL currently explored                   */
+    uint8_t       attemptedTTL;        /**< The ttl as given to the client           */
     uint8_t       replyTTL;            /**< Current TTL sent back with the reply		 */
 		double				rtt;								 /**< Current rtt                   					 */
 		uint32_t			asn;								 /**< Current ASN if resolution is required		 */
+    bool          newHop;              /**< Whether it's a new hop or not. If not, it's just a new probe           */
 		char					ip[INET6_ADDRSTRLEN];/**< Current replying IP											 */
 		char				* hostName;						 /**< Current host name. Should be freed if filled by discovered_ip_dump() */
     size_t        num_replies;         /**< Total of probe sent for this instance    */

--- a/libparistraceroute/algorithms/traceroute.h
+++ b/libparistraceroute/algorithms/traceroute.h
@@ -120,7 +120,7 @@ typedef struct {
 typedef struct {
     bool          destination_reached; /**< True iif the destination has been reached at least once for the current TTL */
     uint8_t       ttl;                 /**< TTL currently explored                   */
-    uint8_t       attemptedTTL;        /**< The ttl as given to the client           */
+    uint8_t       attemptTTL;          /**< The ttl as given to the client           */
     uint8_t       replyTTL;            /**< Current TTL sent back with the reply		 */
 		double				rtt;								 /**< Current rtt                   					 */
 		uint32_t			asn;								 /**< Current ASN if resolution is required		 */

--- a/libparistraceroute/common.c
+++ b/libparistraceroute/common.c
@@ -6,6 +6,9 @@
 
 #include "common.h"
 
+// Does the library do print results. Default is yes for compatibility purpose
+bool _doPrint = true;
+
 // Note: for measuring intervals !
 //#include <time.h>
 //struct timespec ts;
@@ -25,5 +28,9 @@ void print_indent(unsigned int indent)
     for(i = 0; i < indent; i++) {
         printf("    ");
     }
+}
+
+void setPrintMode(bool iDoPrint) {
+		_doPrint = iDoPrint;
 }
 

--- a/libparistraceroute/common.h
+++ b/libparistraceroute/common.h
@@ -2,6 +2,7 @@
 #define LIBPT_COMMON_H
 
 #include <stdio.h> // FILE *
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,12 +73,19 @@ extern "C" {
 double get_timestamp();
 
 /**
- * \bruef Print some space characters
+ * \brief Print some space characters
  * \param indent The number of space characters to print
  *   in the standard output
  */
 
 void print_indent(unsigned int indent);
+
+/*
+ * For a compatibility purpose only, since the lib shouldn't print anything but store data to be printed
+ * by its client.
+ * \param iDoPrint if true, traceroute_handler() acts as default so far, and prints everything(ttl, ip, resolved host name)
+ */
+void setPrintMode(bool iDoPrint);
 
 #ifdef __cplusplus
 }

--- a/libparistraceroute/common.h
+++ b/libparistraceroute/common.h
@@ -3,6 +3,10 @@
 
 #include <stdio.h> // FILE *
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
 //---------------------------------------------------------------------------
 // Callback types.
 //---------------------------------------------------------------------------
@@ -74,5 +78,9 @@ double get_timestamp();
  */
 
 void print_indent(unsigned int indent);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_COMMON_H

--- a/libparistraceroute/event.h
+++ b/libparistraceroute/event.h
@@ -3,6 +3,10 @@
 
 // Do not include "algorithm.h" to avoid mutual inclusion
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \file event.h
  * \brief
@@ -71,5 +75,9 @@ event_t * event_create(
  */
 
 void event_free(event_t * event);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_EVENT_H

--- a/libparistraceroute/field.h
+++ b/libparistraceroute/field.h
@@ -12,6 +12,10 @@
 
 #include "address.h" // address_t, ipv4_t, ipv6_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct generator_s;
 
 typedef union{
@@ -432,5 +436,9 @@ bool field_set_value(field_t * field, void * value);
  */
 
 void field_dump(const field_t * field);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_FIELD_H

--- a/libparistraceroute/lattice.h
+++ b/libparistraceroute/lattice.h
@@ -3,6 +3,10 @@
 
 #include "dynarray.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
     LATTICE_DONE,
     LATTICE_CONTINUE,
@@ -118,5 +122,9 @@ bool lattice_add_element(lattice_t * lattice, lattice_elt_t * predecessor, void 
  *    pass NULL if unused.
  */
 void lattice_dump(lattice_t * lattice, void (* element_dump)(const void *));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_LATTICE_H

--- a/libparistraceroute/network.h
+++ b/libparistraceroute/network.h
@@ -36,6 +36,10 @@
 #define OPTIONS_NETWORK_WAIT {NETWORK_DEFAULT_TIMEOUT, 0, INT_MAX}
 #define HELP_w "Set the number of seconds to wait for response to a probe (default is 5.0)"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \struct network_t
  * \brief Structure describing a network
@@ -338,6 +342,10 @@ int network_get_icmpv4_sockfd(network_t * network);
  */
 
 int network_get_icmpv6_sockfd(network_t * network);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif // LIBPT_NETWORK_H

--- a/libparistraceroute/options.h
+++ b/libparistraceroute/options.h
@@ -7,6 +7,10 @@
 
 #define END_OPT_SPECS { .action = NULL}
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //---------------------------------------------------------------------------
 // option_t
 //---------------------------------------------------------------------------
@@ -117,5 +121,9 @@ void options_dump(const options_t * options);
  * \param args vector containing the arguments passed
  */
 int options_parse(options_t * options, const char * usage, char ** args);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_OPTIONS_H

--- a/libparistraceroute/optparse.h
+++ b/libparistraceroute/optparse.h
@@ -8,6 +8,10 @@
 #define OPT_NO_HELP (void *)0
 #define OPT_NO_DATA (void *)0
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * \brief a structure describing a command line option
  * \action the function to be called to handle the data option
@@ -220,5 +224,9 @@ int opt_parse(const char * usage, struct opt_spec * opts, char **argv);
  */
 
 char ***opt_remainder(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_OPTPARSE_H

--- a/libparistraceroute/os/sys/eventfd.h
+++ b/libparistraceroute/os/sys/eventfd.h
@@ -7,6 +7,10 @@
 #  include <sys/eventfd.h>
 #endif
 
+#ifdef __ANDROID__
+#define EFD_SEMAPHORE 00000001
+#endif
+
 #ifdef FREEBSD
 #  include <stdio.h>
 #  include <stdint.h>

--- a/libparistraceroute/packet.h
+++ b/libparistraceroute/packet.h
@@ -9,6 +9,10 @@
 #include "buffer.h"    // buffer_t
 #include "address.h"   // address_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \struct packet_t
  * \brief Structure describing a network packet
@@ -118,5 +122,9 @@ int packet_guess_address_family(const packet_t * packet);
 buffer_t * packet_get_buffer(packet_t * packet);
 
 void packet_set_buffer(packet_t * packet, buffer_t * buffer);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_PACKET_H

--- a/libparistraceroute/probe.h
+++ b/libparistraceroute/probe.h
@@ -17,6 +17,11 @@
 #include "use.h"
 
 #define DELAY_BEST_EFFORT -1 // This MUST be < 0, see network_send_probe
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \struct probe_t
  * \brief Structure representing a probe
@@ -385,5 +390,9 @@ void probe_reply_set_probe(probe_reply_t * probe_reply, probe_t * probe);
 probe_t * probe_reply_get_probe(const probe_reply_t * probe_reply);
 void probe_reply_set_reply(probe_reply_t *probe_reply, probe_t * reply);
 probe_t * probe_reply_get_reply(const probe_reply_t * probe_reply);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_PROBE_H

--- a/libparistraceroute/pt_loop.h
+++ b/libparistraceroute/pt_loop.h
@@ -23,6 +23,10 @@
 #include "network.h"
 #include "event.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //---------------------------------------------------------------------------
 // pt_loop options
 //---------------------------------------------------------------------------
@@ -214,5 +218,9 @@ bool pt_raise_error(pt_loop_t * loop);
  */
 
 bool pt_raise_terminated(pt_loop_t * loop);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LIBPT_PT_LOOP_H

--- a/paris-ping/paris-ping.c
+++ b/paris-ping/paris-ping.c
@@ -481,7 +481,7 @@ int main(int argc, char ** argv)
     options_pt_loop_init(loop);
 
     printf("paris-ping to %s (", dst_ip);
-    address_dump(&dst_addr);
+    address_dump(&dst_addr, NULL, 0);
     printf(")\n");
 
     // Add an algorithm instance in the main loop

--- a/paris-traceroute/paris-traceroute.c
+++ b/paris-traceroute/paris-traceroute.c
@@ -206,7 +206,7 @@ void loop_handler(pt_loop_t * loop, event_t * event, void * user_data)
 {
     traceroute_event_t         * traceroute_event;
     const traceroute_options_t * traceroute_options;
-    const traceroute_data_t    * traceroute_data;
+    traceroute_data_t    			 * traceroute_data;
     mda_event_t                * mda_event;
     mda_data_t                 * mda_data;
     const char                 * algorithm_name;
@@ -440,7 +440,7 @@ int main(int argc, char ** argv)
     options_pt_loop_init(loop);
 
     printf("%s to %s (", algorithm_name, dst_ip);
-    address_dump(&dst_addr);
+    address_dump(&dst_addr, NULL, 0);
     printf("), %u hops max, %u bytes packets\n",
         ptraceroute_options->max_ttl,
         (unsigned int)packet_get_size(probe->packet)

--- a/traceroute/traceroute.c
+++ b/traceroute/traceroute.c
@@ -20,7 +20,7 @@ void loop_handler(pt_loop_t * loop, event_t * event, void * user_data)
 {
     traceroute_event_t         * traceroute_event;
     const traceroute_options_t * traceroute_options;
-    const traceroute_data_t    * traceroute_data;
+    traceroute_data_t    			 * traceroute_data;
     const char                 * algorithm_name;
 
     switch (event->type) {


### PR DESCRIPTION
Hi,

I needed libparistraceroute on Android. And also to export its data as a library rather than printing it.
Changes only impact the paris-traceroute algorithm, but not the mda one.
It still print data by default, cf traceroute.c:setPrintMode(), but exports anyway data through traceroute_data_t.

Regards.